### PR TITLE
Fix powerpc defined macros

### DIFF
--- a/include/__libunwind_config.h
+++ b/include/__libunwind_config.h
@@ -26,7 +26,7 @@
 #  define _LIBUNWIND_CONTEXT_SIZE 21
 #  define _LIBUNWIND_CURSOR_SIZE 33
 #  define _LIBUNWIND_HIGHEST_DWARF_REGISTER 17
-# elif defined(__ppc__)
+# elif defined(__ppc__) || defined(__powerpc__)
 #  define _LIBUNWIND_TARGET_PPC 1
 #  define _LIBUNWIND_CONTEXT_SIZE 117
 #  define _LIBUNWIND_CURSOR_SIZE 128

--- a/src/UnwindRegistersSave.S
+++ b/src/UnwindRegistersSave.S
@@ -96,7 +96,7 @@ DEFINE_LIBUNWIND_FUNCTION(unw_getcontext)
 DEFINE_LIBUNWIND_FUNCTION(unw_getcontext)
   teq $0, $0
 
-#elif defined(__ppc__)
+#elif defined(__ppc__) || defined(__powerpc__)
 
 ;
 ; extern int unw_getcontext(unw_context_t* thread_state)

--- a/src/config.h
+++ b/src/config.h
@@ -52,12 +52,12 @@
 #define _LIBUNWIND_BUILD_SJLJ_APIS
 #endif
 
-#if defined(__i386__) || defined(__x86_64__) || defined(__ppc__) || defined(__ppc64__)
+#if defined(__i386__) || defined(__x86_64__) || defined(__ppc__) || defined(__powerpc__) || defined(__ppc64__) || defined(__powerpc64__)
 #define _LIBUNWIND_SUPPORT_FRAME_APIS
 #endif
 
 #if defined(__i386__) || defined(__x86_64__) ||                                \
-    defined(__ppc__) || defined(__ppc64__) ||                                  \
+    defined(__ppc__) || defined(__powerpc__) || defined(__ppc64__) || defined(__powerpc64__)                                 \
     (!defined(__APPLE__) && defined(__arm__)) ||                               \
     (defined(__arm64__) || defined(__aarch64__)) ||                            \
     (defined(__APPLE__) && defined(__mips__))

--- a/src/libunwind.cpp
+++ b/src/libunwind.cpp
@@ -50,7 +50,7 @@ _LIBUNWIND_EXPORT int unw_init_local(unw_cursor_t *cursor,
 # define REGISTER_KIND Registers_x86
 #elif defined(__x86_64__)
 # define REGISTER_KIND Registers_x86_64
-#elif defined(__ppc__)
+#elif defined(__ppc__) || defined(__powerpc__)
 # define REGISTER_KIND Registers_ppc
 #elif defined(__aarch64__)
 # define REGISTER_KIND Registers_arm64


### PR DESCRIPTION
Currently libunwind checks for __ppc__ macro to check if it is being
compiled on a powerpc system.

Depending on where you are compiling, as Alpine Linux, the proper macro
is __powerpc__ instead of __ppc__. The same thing for the 64 bit
variant, which should be __powerpc64__ instead of __ppc64__.